### PR TITLE
Allow empty strings in final_snapshot_identifier

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -89,7 +89,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 					value := v.(string)
-					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+					if len(value) > 0 && !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 						es = append(es, fmt.Errorf(
 							"only alphanumeric characters and hyphens allowed in %q", k))
 					}


### PR DESCRIPTION
This is a quick fix for #6786. It modifies the `ValidateFunc` so that empty strings are allowed. Elsewhere, [the code already handles empty strings](https://github.com/hashicorp/terraform/blob/27f05b8e3b64bb67cbefc6a38df6b4a21c504291/builtin/providers/aws/resource_aws_rds_cluster.go#L376).
